### PR TITLE
Add uploads index regeneration endpoint and folder controls

### DIFF
--- a/php/api/regenerate.php
+++ b/php/api/regenerate.php
@@ -1,0 +1,37 @@
+<?php
+$allowed_origin = 'https://3dobjcttest.yashubustudioetc.com';
+
+if (isset($_SERVER['HTTP_ORIGIN'])) {
+    if ($_SERVER['HTTP_ORIGIN'] === $allowed_origin) {
+        header("Access-Control-Allow-Origin: $allowed_origin");
+        header("Access-Control-Allow-Methods: GET, OPTIONS");
+        header("Access-Control-Allow-Headers: Content-Type");
+    } else {
+        http_response_code(403);
+        echo json_encode(['error' => 'CORS policy: origin not allowed']);
+        exit;
+    }
+}
+
+header('Content-Type: application/json');
+
+$baseDir = __DIR__ . '/uploads/';
+if (!is_dir($baseDir)) {
+    mkdir($baseDir, 0755, true);
+}
+
+$folders = array_values(array_filter(scandir($baseDir), function ($f) use ($baseDir) {
+    return $f !== '.' && $f !== '..' && is_dir($baseDir . $f);
+}));
+
+foreach ($folders as $folder) {
+    $folderDir = $baseDir . $folder . '/';
+    $files = array_values(array_filter(scandir($folderDir), function ($f) use ($folderDir) {
+        return $f !== '.' && $f !== '..' && is_file($folderDir . $f);
+    }));
+    file_put_contents($folderDir . 'index.json', json_encode($files));
+}
+
+file_put_contents($baseDir . 'index.json', json_encode($folders));
+
+echo json_encode(['success' => true, 'folders' => $folders]);

--- a/src/pages/Folder.jsx
+++ b/src/pages/Folder.jsx
@@ -7,8 +7,8 @@ export default function Folder() {
   const [selectedFolder, setSelectedFolder] = useState(null);
   const [files, setFiles] = useState([]);
 
-  // フォルダ一覧を読み込む
-  useEffect(() => {
+  // フォルダ一覧を読み込む処理を関数化
+  const loadFolders = () => {
     fetch("/api/uploads/index.json")
       .then((res) => {
         if (!res.ok) throw new Error("フォルダ一覧取得失敗");
@@ -16,6 +16,10 @@ export default function Folder() {
       })
       .then(setFolders)
       .catch((err) => console.error("フォルダ一覧の取得に失敗:", err));
+  };
+
+  useEffect(() => {
+    loadFolders();
   }, []);
 
   // 選択フォルダのファイル一覧を取得
@@ -33,12 +37,43 @@ export default function Folder() {
     }
   }, [selectedFolder]);
 
+  // 状態再生成を呼び出す
+  const handleRegenerate = () => {
+    fetch("/api/regenerate.php")
+      .then((res) => {
+        if (!res.ok) throw new Error("再生成に失敗");
+        return res.json();
+      })
+      .then(() => loadFolders())
+      .catch((err) => console.error("再生成エラー:", err));
+  };
+
+  // モデルをダウンロード
+  const handleDownloadModel = () => {
+    const modelFile = files.find((f) => /\.(glb|gltf|zip)$/i.test(f));
+    if (modelFile) {
+      const link = document.createElement("a");
+      link.href = `/api/uploads/${selectedFolder}/${modelFile}`;
+      link.download = modelFile;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    }
+  };
+
   return (
     <Box sx={{ p: 3 }}>
       <Typography variant="h5" gutterBottom>
         アップロードフォルダ一覧（運営確認用）
       </Typography>
       <Box sx={{ mb: 2 }}>
+        <Button
+          variant="contained"
+          onClick={handleRegenerate}
+          sx={{ mr: 1, mb: 1 }}
+        >
+          状態再生成
+        </Button>
         {folders.map((folder, idx) => (
           <Button
             key={idx}
@@ -56,6 +91,13 @@ export default function Folder() {
           <Typography variant="h6" gutterBottom>
             📁 {selectedFolder} の中身
           </Typography>
+          <Button
+            variant="contained"
+            onClick={handleDownloadModel}
+            sx={{ mb: 2 }}
+          >
+            モデルをダウンロード
+          </Button>
           <ul>
             {files.map((file, idx) => (
               <li key={idx}>


### PR DESCRIPTION
## Summary
- add PHP endpoint to rescan uploads and rebuild index.json files
- add UI buttons to trigger state regeneration and download current model

## Testing
- `npm test -- --watchAll=false` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688e2135d3388323aff5ba914c0d843f