### PR TITLE
Allow regenerate and upload endpoints

### DIFF
--- a/php/api/.htaccess
+++ b/php/api/.htaccess
@@ -10,6 +10,17 @@
 </If>
 
 # -----------------------------------------------
+# ✅ /api/upload.php と /api/regenerate.php を許可
+# -----------------------------------------------
+<If "%{REQUEST_URI} =~ m#^/api/(upload|regenerate)\.php$#">
+  Require all granted
+  Header set Access-Control-Allow-Origin "https://3dobjcttest.yashubustudioetc.com"
+  Header always set Access-Control-Allow-Methods "GET, POST, OPTIONS"
+  Header always set Access-Control-Allow-Headers "Content-Type"
+  Header set Content-Type "application/json"
+</If>
+
+# -----------------------------------------------
 # ✅ /api/uploads/ 閲覧のみ許可、その他の /api/ は非公開
 # -----------------------------------------------
 <If "%{REQUEST_URI} =~ m#^/api/uploads/#">


### PR DESCRIPTION
## Summary
- permit `/api/upload.php` and `/api/regenerate.php` through `.htaccess`
- add CORS headers for new endpoints

## Testing
- `CI=true npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688e261dc57483238d174d3109dfbb1e