### PR TITLE
Allow regenerate script via updated htaccess and CORS handling

### DIFF
--- a/htaccess.image.txt
+++ b/htaccess.image.txt
@@ -23,10 +23,10 @@
 </If>
 
 # -----------------------------------------------
-# ✅ /api/upload（保存用スクリプト）や /api/ の保護設定
+# ✅ /api/ の保護設定（uploads/, ping.php, regenerate.php を除く）
 # → 外部からアクセスさせない、一覧も非表示
 # -----------------------------------------------
-<If "%{REQUEST_URI} =~ m#^/api/(?!uploads/|ping\.php$)#">
+<If "%{REQUEST_URI} =~ m#^/api/(?!uploads/|ping\.php$|regenerate\.php$)#">
   Options -Indexes
 
   <IfModule mod_headers.c>


### PR DESCRIPTION
## Summary
- Allow `/api/regenerate.php` by excluding it from global API protection rules
- Handle CORS preflight and disallowed origins directly in `regenerate.php`
- Skip generated index files when rebuilding folder listings

## Testing
- `php -l php/api/regenerate.php`
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token in three/examples/jsm/loaders/GLTFLoader.js)*

------
https://chatgpt.com/codex/tasks/task_e_688e2bb83f1c8323a6e02e9c6bff9bac